### PR TITLE
Add the seconds unit to the transition property. It was missing before.

### DIFF
--- a/Natours/sass/layouts/_navigation.scss
+++ b/Natours/sass/layouts/_navigation.scss
@@ -54,7 +54,7 @@
         z-index: 1500;
         opacity: 0;
         width: 0;
-        transition: all .8 cubic-bezier(0.68, -0.55, 0.265, 1.55);
+        transition: all .8s cubic-bezier(0.68, -0.55, 0.265, 1.55);
     }
     &__list {
         position: absolute;


### PR DESCRIPTION
I had an issue at one point during the course with regards to animating navigation styles. I ended up just copying the file over from your source repo and I found that there was still an issue, namely that in your "navigation.scss" partial, the "s" seconds unit is missing in the `nav` selector for the `transition` property. I added it for this PR.